### PR TITLE
Poll more often for device to disappear for busy or slow systems

### DIFF
--- a/tests/test_createmany_checkclose
+++ b/tests/test_createmany_checkclose
@@ -90,7 +90,7 @@ for ((i = 0; i < 400; i++)); do
 	fi
 
 	kill -9 $(cat $tmpdir/vtpmctrl.pid.${i})
-	for ((j = 0; j < 10; j++)); do
+	for ((j = 0; j < 30; j++)); do
 		# wait for device to disappear
 		if [ ! -c $tpmdev ]; then
 			break;

--- a/tests/test_tpm2_createmany_checkclose
+++ b/tests/test_tpm2_createmany_checkclose
@@ -87,7 +87,7 @@ for ((i = 0; i < 400; i++)); do
 	fi
 
 	kill -9 $(cat $tmpdir/vtpmctrl.pid.${i})
-	for ((j = 0; j < 10; j++)); do
+	for ((j = 0; j < 30; j++)); do
 		# wait for device to disappear
 		if [ ! -c $tpmdev ]; then
 			break;


### PR DESCRIPTION
Busy or slow systems may not have a chance to remove a device
that quickly, so poll for it a bit longer.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>